### PR TITLE
🧹 refactor(utils): remove 'any' casts from window object

### DIFF
--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -1,0 +1,4 @@
+interface Window {
+  MSStream?: any;
+  webkitAudioContext?: typeof AudioContext;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,7 @@
 const isIOS = () => {
   if (typeof window === "undefined") return false
   return (
-    /iPad|iPhone|iPod/.test(navigator.userAgent) && !(window as any).MSStream
+    /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream
   )
 }
 
@@ -10,7 +10,7 @@ const playTapSound = (duration: number) => {
   if (typeof window === "undefined") return
   try {
     const audioContext = new (
-      window.AudioContext || (window as any).webkitAudioContext
+      window.AudioContext || window.webkitAudioContext
     )()
     const oscillator = audioContext.createOscillator()
     const gainNode = audioContext.createGain()


### PR DESCRIPTION
🎯 **What:** Removed the `(window as any)` casts from `src/utils/index.ts` and added an augmentation file for the global `Window` interface to include the missing non-standard properties `MSStream` and `webkitAudioContext`.
💡 **Why:** Using `any` bypasses the type-checker. By properly augmenting the global `Window` interface, we improve type safety and maintainability of code that requires checking for iOS devices.
✅ **Verification:** Verified with `bun x tsc --noEmit` and confirmed that `window.MSStream` and `window.webkitAudioContext` type check perfectly.
✨ **Result:** A safer, cleaner codebase that relies on proper TypeScript definitions.

---
*PR created automatically by Jules for task [14158954888569998333](https://jules.google.com/task/14158954888569998333) started by @aashutoshrathi*