### PR TITLE
🔒 Fix XSS risk by removing dangerouslySetInnerHTML in gatsby-ssr.ts

### DIFF
--- a/gatsby-ssr.ts
+++ b/gatsby-ssr.ts
@@ -3,25 +3,10 @@ import React from "react"
 import { RenderBodyArgs } from "gatsby"
 
 export const onRenderBody = ({ setPreBodyComponents }: RenderBodyArgs) => {
-  const themeScript = `
-    (function() {
-      function getTheme() {
-        if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-          return 'dark';
-        }
-        return 'light';
-      }
-      
-      const theme = getTheme();
-      document.documentElement.setAttribute('data-theme', theme);
-      document.documentElement.classList.add(theme);
-    })();
-  `
-
   setPreBodyComponents([
     React.createElement("script", {
       key: "theme-script",
-      dangerouslySetInnerHTML: { __html: themeScript },
+      src: "/theme.js",
     }),
   ])
 }

--- a/static/theme.js
+++ b/static/theme.js
@@ -1,0 +1,12 @@
+(function() {
+  function getTheme() {
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      return 'dark';
+    }
+    return 'light';
+  }
+
+  const theme = getTheme();
+  document.documentElement.setAttribute('data-theme', theme);
+  document.documentElement.classList.add(theme);
+})();


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
This PR removes the use of `dangerouslySetInnerHTML` in `gatsby-ssr.ts` which was being used to inject an inline script for theme initialization. The script logic has been extracted to a standalone file `static/theme.js` and is now included via a `src` attribute on the script tag.

⚠️ **Risk:** The potential impact if left unfixed
While the previous inline script was hardcoded and not immediately exploitable, using `dangerouslySetInnerHTML` is inherently risky and is flagged as a potential Cross-Site Scripting (XSS) vulnerability. Left unfixed, future modifications to the script generation could inadvertently introduce an XSS flaw if user-controlled data ever became part of that string.

🛡️ **Solution:** How the fix addresses the vulnerability
The fix entirely eliminates the `dangerouslySetInnerHTML` prop. By placing the theme script into Gatsby's `static` folder as `theme.js`, it becomes a normal static asset served at the root path (`/theme.js`). `gatsby-ssr.ts` now safely injects a `<script src="/theme.js">` tag into the document head, completely removing the dangerous API call without affecting functionality.

---
*PR created automatically by Jules for task [6059692788602479245](https://jules.google.com/task/6059692788602479245) started by @aashutoshrathi*