### PR TITLE
🧪 Add error path test for playTapSound fallback

### DIFF
--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,5 +1,37 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test"
-import { fetchData } from "./index"
+import { fetchData, hapticFeedback } from "./index"
+
+describe("hapticFeedback", () => {
+  let originalWindow: typeof globalThis.window
+  let originalNavigator: typeof globalThis.navigator
+
+  beforeEach(() => {
+    originalWindow = globalThis.window
+    originalNavigator = globalThis.navigator
+  })
+
+  afterEach(() => {
+    globalThis.window = originalWindow
+    globalThis.navigator = originalNavigator
+  })
+
+  it("should not throw when iOS AudioContext throws an error", () => {
+    // @ts-ignore
+    globalThis.navigator = {
+      userAgent: "iPhone",
+    }
+
+    // @ts-ignore
+    globalThis.window = {
+      MSStream: undefined,
+      AudioContext: mock().mockImplementation(() => {
+        throw new Error("AudioContext error")
+      }),
+    }
+
+    expect(() => hapticFeedback(10)).not.toThrow()
+  })
+})
 
 describe("fetchData", () => {
   let originalWindow: typeof globalThis.window


### PR DESCRIPTION
🎯 **What:** Added missing test coverage for the error path of the iOS fallback in `hapticFeedback` (`src/utils/index.ts`), where an error during `AudioContext` instantiation is caught and silently ignored.
📊 **Coverage:** Specifically covers the scenario where `isIOS()` is true but `window.AudioContext` initialization throws an error.
✨ **Result:** Increased test coverage for `hapticFeedback`, guaranteeing robustness and verifying that an unavailable or failing audio context on iOS does not crash the application.

---
*PR created automatically by Jules for task [16629015221298117782](https://jules.google.com/task/16629015221298117782) started by @aashutoshrathi*