### PR TITLE
🧪 [testing improvement] Add missing test for iOS playTapSound fallback

### DIFF
--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,5 +1,36 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test"
-import { fetchData } from "./index"
+import { fetchData, hapticFeedback } from "./index"
+
+describe("hapticFeedback", () => {
+  let originalWindow: typeof globalThis.window
+  let originalNavigator: typeof globalThis.navigator
+
+  beforeEach(() => {
+    originalWindow = globalThis.window
+    originalNavigator = globalThis.navigator
+  })
+
+  afterEach(() => {
+    globalThis.window = originalWindow
+    globalThis.navigator = originalNavigator
+  })
+
+  it("should silently fail if AudioContext throws an error on iOS fallback", () => {
+    // @ts-ignore
+    globalThis.window = {
+      AudioContext: mock().mockImplementation(() => {
+        throw new Error("AudioContext not supported")
+      }),
+    }
+
+    // @ts-ignore
+    globalThis.navigator = {
+      userAgent: "iPhone",
+    }
+
+    expect(() => hapticFeedback(10)).not.toThrow()
+  })
+})
 
 describe("fetchData", () => {
   let originalWindow: typeof globalThis.window


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Added a missing unit test to cover the `playTapSound` error fallback logic (which triggers if `window.AudioContext` instantiation throws an error on iOS devices).

📊 **Coverage:** What scenarios are now tested
Simulated an iOS device userAgent and mocked `window.AudioContext` to throw an error, explicitly asserting that the `catch` block correctly swallows the exception and `hapticFeedback()` gracefully exits without throwing.

✨ **Result:** The improvement in test coverage
Increased the robustness of testing for the `hapticFeedback` utility by directly testing its failure paths, preventing regressions to error-handling behavior during future updates. Tests passed successfully without side effects.

---
*PR created automatically by Jules for task [6306483503086504898](https://jules.google.com/task/6306483503086504898) started by @aashutoshrathi*