### PR TITLE
🔒 Fix Insecure Content Security Policy (CSP) Directives

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,16 +5,6 @@ dotenv.config({
   path: `.env`,
 })
 
-const cspDirectives = [
-  "script-src 'self' 'unsafe-inline' *.cloudfront.net unpkg.com www.google-analytics.com www.googletagmanager.com",
-  "style-src 'self' 'unsafe-inline' fonts.googleapis.com fonts.gstatic.com",
-  "img-src 'self' data: https:",
-  "font-src 'self' data: fonts.googleapis.com fonts.gstatic.com",
-  "worker-src 'self' blob: data:",
-  "connect-src 'self' 'unsafe-inline' api.aashutosh.dev github-contributions-api.jogruber.de www.google-analytics.com stats.g.doubleclick.net www.googletagmanager.com",
-  "object-src 'none'",
-]
-
 module.exports = {
   siteMetadata: {
     title: `aashutosh.dev`,
@@ -109,11 +99,31 @@ module.exports = {
       },
     },
     {
+      resolve: `gatsby-plugin-csp`,
+      options: {
+        disableOnDev: true,
+        reportOnly: false,
+        mergeScriptHashes: true,
+        mergeStyleHashes: true,
+        mergeDefaultDirectives: true,
+        directives: {
+          "script-src":
+            "'self' *.cloudfront.net unpkg.com www.google-analytics.com www.googletagmanager.com",
+          "style-src": "'self' fonts.googleapis.com fonts.gstatic.com",
+          "img-src": "'self' data: https:",
+          "font-src": "'self' data: fonts.googleapis.com fonts.gstatic.com",
+          "worker-src": "'self' blob: data:",
+          "connect-src":
+            "'self' api.aashutosh.dev github-contributions-api.jogruber.de www.google-analytics.com stats.g.doubleclick.net www.googletagmanager.com",
+          "object-src": "'none'",
+        },
+      },
+    },
+    {
       resolve: "gatsby-plugin-netlify",
       options: {
         headers: {
           "/*": [
-            `Content-Security-Policy: ${cspDirectives.join(";")}`,
             "Feature-Policy: sync-xhr 'self'",
             "X-Frame-Options: DENY",
             "Strict-Transport-Security: max-age=31536000; includeSubDomains; preload",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "dotenv": "^8.2.0",
         "gatsby": "^5.15.0",
         "gatsby-plugin-alias-imports": "^1.0.5",
+        "gatsby-plugin-csp": "^1.1.4",
         "gatsby-plugin-google-gtag": "^5.15.0",
         "gatsby-plugin-image": "^3.15.0",
         "gatsby-plugin-layout": "^4.15.0",
@@ -10848,6 +10849,16 @@
         "gatsby": ">2.0.0"
       }
     },
+    "node_modules/gatsby-plugin-csp": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-csp/-/gatsby-plugin-csp-1.1.4.tgz",
+      "integrity": "sha512-aMDN27QAbHcI/3F5sH9J3w4wE0vNWWKTxGXjQ4VsKVVbIfxnPNXf82i9nOp4Ef2MQT4bIKnfZjf9jaLG3aWXcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "lodash.flatten": "^4.4.0"
+      }
+    },
     "node_modules/gatsby-plugin-google-gtag": {
       "version": "5.15.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-google-gtag/-/gatsby-plugin-google-gtag-5.15.0.tgz",
@@ -13903,6 +13914,12 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.every/-/lodash.every-4.6.0.tgz",
       "integrity": "sha512-isF82d+65/sNvQ3aaQAW7LLHnnTxSN/2fm4rhYyuufLzA4VtHz6y6S5vFwe6PQVr2xdqUOyxBbTNKDpnmeu50w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "license": "MIT"
     },
     "node_modules/lodash.flattendeep": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dotenv": "^8.2.0",
     "gatsby": "^5.15.0",
     "gatsby-plugin-alias-imports": "^1.0.5",
+    "gatsby-plugin-csp": "^1.1.4",
     "gatsby-plugin-google-gtag": "^5.15.0",
     "gatsby-plugin-image": "^3.15.0",
     "gatsby-plugin-layout": "^4.15.0",


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the presence of `'unsafe-inline'` in the Content Security Policy (CSP) directives (`script-src` and `style-src`) in `gatsby-config.js`.
⚠️ **Risk:** The potential impact if left unfixed is that it allows the execution of arbitrary inline scripts and styles, exposing the site to Cross-Site Scripting (XSS) attacks. If an attacker manages to inject a `<script>` tag into the page, the browser would execute it.
🛡️ **Solution:** The fix removes `'unsafe-inline'` from the CSP directives. To ensure legitimate inline scripts and styles (injected by Gatsby plugins) continue to work, `gatsby-plugin-csp` was installed and configured. This plugin automatically parses the generated HTML files during the build process, computes SHA-256 hashes for all inline `<script>` and `<style>` tags, and injects a strict CSP `<meta>` tag into the `<head>` of each page. The static CSP header from `gatsby-plugin-netlify` was also removed to prevent conflicts and header bloat.

---
*PR created automatically by Jules for task [8583509049701464991](https://jules.google.com/task/8583509049701464991) started by @aashutoshrathi*