### PR TITLE
🧹 refactor: remove non-null assertions in useGSAP hook

### DIFF
--- a/src/pages/uses.tsx
+++ b/src/pages/uses.tsx
@@ -146,6 +146,8 @@ const UsesPage: React.FC = () => {
   const subHeadingRef = useRef<HTMLParagraphElement | null>(null)
 
   useGSAP(() => {
+    if (!usesRef.current) return
+
     const tl = gsap.timeline()
 
     tl.from(headingRef.current, {
@@ -160,7 +162,7 @@ const UsesPage: React.FC = () => {
         ease: "power2.out",
         duration: 0.2,
       })
-      .from(usesRef.current?.querySelectorAll(".section")!, {
+      .from(usesRef.current.querySelectorAll(".section"), {
         y: -8,
         opacity: 0,
         ease: "power2.out",
@@ -168,7 +170,7 @@ const UsesPage: React.FC = () => {
         duration: 0.2,
       })
       .from(
-        usesRef.current?.querySelectorAll(".section-item")!,
+        usesRef.current.querySelectorAll(".section-item"),
         {
           y: -8,
           opacity: 0,


### PR DESCRIPTION
🎯 **What:** Removed the non-null assertion operators (`!`) combined with optional chaining (`?.`) from the `.querySelectorAll()` calls within the `useGSAP` hook in `src/pages/uses.tsx` (lines 163 and 171).
💡 **Why:** Relying on non-null assertions forces the TypeScript compiler to ignore potential `null` values, which can lead to runtime errors or unsafe state. Adding an early return properly narrows the type and ensures the hook only proceeds when the reference actually exists, which is safer and cleaner React code.
✅ **Verification:** Verified via `bun test` and type-checking with `bun x tsc` that there are no regressions, and the updated code safely handles references.
✨ **Result:** Improved code readability, type safety, and overall health in the GSAP animation logic.

---
*PR created automatically by Jules for task [11309247820632877623](https://jules.google.com/task/11309247820632877623) started by @aashutoshrathi*