### PR TITLE
🧹 refactor(code-block): Remove any type from getTextContent

### DIFF
--- a/src/components/code-block.tsx
+++ b/src/components/code-block.tsx
@@ -13,10 +13,19 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ children, className }) => {
   const handleCopy = async () => {
     mediumHaptic()
     // Extract text content from children
-    const getTextContent = (node: any): string => {
+    const getTextContent = (node: React.ReactNode): string => {
       if (typeof node === "string") return node
       if (Array.isArray(node)) return node.map(getTextContent).join("")
-      if (node?.props?.children) return getTextContent(node.props.children)
+      if (
+        React.isValidElement(node) &&
+        node.props &&
+        typeof node.props === "object" &&
+        "children" in node.props
+      ) {
+        return getTextContent(
+          (node.props as { children?: React.ReactNode }).children
+        )
+      }
       return ""
     }
 


### PR DESCRIPTION
🎯 **What:** Removed the `any` type in the `getTextContent` function within `src/components/code-block.tsx` and replaced it with `React.ReactNode`.
💡 **Why:** Using `any` bypasses TypeScript's type checking, leaving the code vulnerable to type-related bugs. Replacing it with `React.ReactNode` and adding explicit type guards (e.g., `React.isValidElement`) makes the implementation safer and robust.
✅ **Verification:** Verified that `bun x tsc --noEmit` and `bun test` ran successfully without regressions. Ensure the component's functionality remained intact via simulated builds.
✨ **Result:** Improved maintainability, safer parameter checking, and a healthier codebase.

---
*PR created automatically by Jules for task [3172209712937393107](https://jules.google.com/task/3172209712937393107) started by @aashutoshrathi*