### PR TITLE
🧹 Replace `any` type with `ReactNode` in code-block.tsx

### DIFF
--- a/src/components/code-block.tsx
+++ b/src/components/code-block.tsx
@@ -13,10 +13,16 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ children, className }) => {
   const handleCopy = async () => {
     mediumHaptic()
     // Extract text content from children
-    const getTextContent = (node: any): string => {
-      if (typeof node === "string") return node
-      if (Array.isArray(node)) return node.map(getTextContent).join("")
-      if (node?.props?.children) return getTextContent(node.props.children)
+    const getTextContent = (node: React.ReactNode): string => {
+      if (typeof node === "string" || typeof node === "number") {
+        return String(node)
+      }
+      if (Array.isArray(node)) {
+        return node.map(getTextContent).join("")
+      }
+      if (React.isValidElement<{ children?: React.ReactNode }>(node)) {
+        return getTextContent(node.props.children)
+      }
       return ""
     }
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was the use of an implicit `any` type in the `getTextContent` function for extracting text content from React component children.
💡 **Why:** `any` bypasses type checking entirely. Strongly typing to `React.ReactNode` explicitly requires proper null checks and prop validation, meaning future refactors and changes will be caught by TypeScript to improve code maintainability and lower the chance of regressions.
✅ **Verification:** I ran `bun x tsc` and `bun test` to ensure tests passed and type safety was maintained. A clean manual review of standard React parsing behavior also ensures that duck typing properties won't cause runtime errors.
✨ **Result:** A fully type-safe `getTextContent` helper method using robust narrowing logic.

---
*PR created automatically by Jules for task [8214592433351409669](https://jules.google.com/task/8214592433351409669) started by @aashutoshrathi*