### PR TITLE
🧪 test: add unit tests for hapticFeedback utility

### DIFF
--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test"
-import { fetchData } from "./index"
+import { fetchData, hapticFeedback } from "./index"
 
 describe("fetchData", () => {
   let originalWindow: typeof globalThis.window
@@ -36,5 +36,117 @@ describe("fetchData", () => {
     const result = await fetchData("https://api.example.com")
     expect(globalThis.fetch).toHaveBeenCalledWith("https://api.example.com")
     expect(result).toEqual(mockResponse)
+  })
+})
+
+describe("hapticFeedback", () => {
+  let originalWindow: typeof globalThis.window
+  let originalNavigator: typeof globalThis.navigator
+
+  beforeEach(() => {
+    originalWindow = globalThis.window
+    originalNavigator = globalThis.navigator
+  })
+
+  afterEach(() => {
+    globalThis.window = originalWindow
+    globalThis.navigator = originalNavigator
+  })
+
+  it("should do nothing if window is undefined", () => {
+    // @ts-ignore
+    delete (globalThis as any).window
+    expect(() => hapticFeedback()).not.toThrow()
+  })
+
+  it("should use AudioContext on iOS with number pattern", () => {
+    const mockStop = mock()
+    const mockAudioContext = mock().mockImplementation(() => ({
+      createOscillator: mock().mockReturnValue({
+        connect: mock(),
+        frequency: { value: 0 },
+        start: mock(),
+        stop: mockStop,
+      }),
+      createGain: mock().mockReturnValue({
+        connect: mock(),
+        gain: { value: 0 },
+      }),
+      destination: {},
+      currentTime: 0,
+    }))
+
+    // @ts-ignore
+    globalThis.window = { AudioContext: mockAudioContext }
+    // @ts-ignore
+    globalThis.navigator = { userAgent: "iPhone" }
+
+    hapticFeedback(15)
+    expect(mockAudioContext).toHaveBeenCalled()
+    expect(mockStop).toHaveBeenCalledWith(0.015) // 0 + 15/1000
+  })
+
+  it("should use webkitAudioContext on iOS with array pattern", () => {
+    const mockStop = mock()
+    const mockAudioContext = mock().mockImplementation(() => ({
+      createOscillator: mock().mockReturnValue({
+        connect: mock(),
+        frequency: { value: 0 },
+        start: mock(),
+        stop: mockStop,
+      }),
+      createGain: mock().mockReturnValue({
+        connect: mock(),
+        gain: { value: 0 },
+      }),
+      destination: {},
+      currentTime: 0,
+    }))
+
+    // @ts-ignore
+    globalThis.window = { webkitAudioContext: mockAudioContext }
+    // @ts-ignore
+    globalThis.navigator = { userAgent: "iPad" }
+
+    hapticFeedback([25, 10, 25])
+    expect(mockAudioContext).toHaveBeenCalled()
+    expect(mockStop).toHaveBeenCalledWith(0.025) // 0 + 25/1000
+  })
+
+  it("should silently fail on iOS if audio context throws an error", () => {
+    const mockAudioContext = mock().mockImplementation(() => {
+      throw new Error("AudioContext not supported")
+    })
+
+    // @ts-ignore
+    globalThis.window = { AudioContext: mockAudioContext }
+    // @ts-ignore
+    globalThis.navigator = { userAgent: "iPhone" }
+
+    expect(() => hapticFeedback(10)).not.toThrow()
+    expect(mockAudioContext).toHaveBeenCalled()
+  })
+
+  it("should use navigator.vibrate if supported on non-iOS", () => {
+    const mockVibrate = mock()
+    // @ts-ignore
+    globalThis.window = {}
+    // @ts-ignore
+    globalThis.navigator = {
+      userAgent: "Android",
+      vibrate: mockVibrate,
+    }
+
+    hapticFeedback(30)
+    expect(mockVibrate).toHaveBeenCalledWith(30)
+  })
+
+  it("should do nothing on non-iOS if vibrate is not supported", () => {
+    // @ts-ignore
+    globalThis.window = {}
+    // @ts-ignore
+    globalThis.navigator = { userAgent: "Android" }
+
+    expect(() => hapticFeedback(10)).not.toThrow()
   })
 })


### PR DESCRIPTION
🎯 **What:** Missing unit tests for the `hapticFeedback` utility function.
📊 **Coverage:** The test suite covers the following scenarios:
  - early return when window is undefined.
  - usage of `AudioContext` on iOS with single duration (number).
  - usage of `webkitAudioContext` on iOS with duration array.
  - fallback behavior silently dropping the error on iOS if AudioContext instantiation or methods fail.
  - standard `navigator.vibrate` usage correctly passing the provided pattern.
  - fallback silent ignoring when `navigator.vibrate` is not supported on non-iOS environments.
✨ **Result:** Test coverage improved for global utility function `hapticFeedback`, ensuring reliable interaction and fallbacks on supported platforms.

---
*PR created automatically by Jules for task [11875658172216662205](https://jules.google.com/task/11875658172216662205) started by @aashutoshrathi*