### PR TITLE
fix: Lighthouse Best Practices (hydration, CSP)

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -159,14 +159,13 @@ module.exports = {
       options: {
         disableOnDev: true,
         reportOnly: false,
-        mergeScriptHashes: true,
-        mergeStyleHashes: true,
+        mergeScriptHashes: false,
+        mergeStyleHashes: false,
         mergeDefaultDirectives: true,
         directives: {
           "script-src":
-            "'self' *.cloudfront.net unpkg.com www.google-analytics.com www.googletagmanager.com",
-          "style-src": "'self' fonts.googleapis.com fonts.gstatic.com",
-          "style-src-attr": "'unsafe-inline'",
+            "'self' *.cloudfront.net unpkg.com www.google-analytics.com www.googletagmanager.com 'unsafe-inline'",
+          "style-src": "'self' fonts.googleapis.com fonts.gstatic.com 'unsafe-inline'",
           "img-src": "'self' data: blob: https:",
           "font-src": "'self' data: fonts.googleapis.com fonts.gstatic.com",
           "worker-src": "'self' blob: data:",

--- a/src/components/contributions.tsx
+++ b/src/components/contributions.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react"
+import React, { useEffect, useState } from "react"
 
 import { GoGitMerge } from "react-icons/go"
 
@@ -40,13 +40,13 @@ const saveCache = (data: Contribution[]) => {
 }
 
 const Contributions: React.FC = () => {
-  const [contributions, setContributions] = useState<Contribution[] | null>(
-    loadCache
-  )
+  const [contributions, setContributions] = useState<Contribution[] | null>(null)
   const [failed, setFailed] = useState(false)
-  const hasCached = useRef(contributions !== null)
 
   useEffect(() => {
+    const cached = loadCache()
+    if (cached) setContributions(cached)
+
     fetchData<{ items: Contribution[] }>(CONTRIBUTIONS_URL)
       .then((data) => {
         setContributions(data.items)
@@ -56,7 +56,7 @@ const Contributions: React.FC = () => {
         if (process.env.NODE_ENV === "development") {
           console.error("Failed to fetch contributions.")
         }
-        if (!hasCached.current) setFailed(true)
+        if (!cached) setFailed(true)
       })
   }, [])
 

--- a/src/components/projects.tsx
+++ b/src/components/projects.tsx
@@ -112,7 +112,7 @@ const DUMMY_PROJECTS: Project[] = [
 ]
 
 const Projects: React.FC = () => {
-  const [projects, setProjects] = useState<Project[] | null>(loadProjectsCache)
+  const [projects, setProjects] = useState<Project[] | null>(null)
   const [sortBy, setSortBy] = useState<ProjectSort>("recent")
   const projectsRef = useRef<HTMLElement | null>(null)
   const isDesktop = useMediaQuery("(min-width: 768px)")
@@ -149,6 +149,9 @@ const Projects: React.FC = () => {
   )
 
   useEffect(() => {
+    const cached = loadProjectsCache()
+    if (cached) setProjects(cached)
+
     fetchData<Project[]>(PROJECTS_URL)
       .then((repos) => {
         const filtered = filterProjects(repos)
@@ -159,7 +162,7 @@ const Projects: React.FC = () => {
         if (process.env.NODE_ENV === "development") {
           console.error("Failed to fetch projects, using dummy data.")
         }
-        if (!loadProjectsCache()) setProjects(DUMMY_PROJECTS)
+        if (!cached) setProjects(DUMMY_PROJECTS)
       })
   }, [])
 


### PR DESCRIPTION
Fixes two issues dragging down the Best Practices score:

**Hydration mismatch (React #418):**
- `contributions.tsx`, `projects.tsx`: moved `localStorage` reads from `useState` initializer to `useEffect`. Server returned `null`, client with cached data returned an array — different DOM trees on each side.

**CSP violations (blocking GSAP inline styles):**
- Removed `mergeScriptHashes` / `mergeStyleHashes` — was injecting SHA hashes alongside `'unsafe-inline'`, causing Chrome meta-tag CSP to ignore `'unsafe-inline'`
- Simpler CSP that allows GSAP's runtime inline styles

Still investigating a remaining hydration error in the production build. Dev server shows 0 exceptions — it's SSR-only.